### PR TITLE
Handle bool variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,5 +28,10 @@ config.py:
 
 The :code:`config` module has :code:`REDIS_URL` as attribute. You might want to change the value for your production environment. In this example, if you have defined :code:`REDIS_URL` in environment variables, when you load :code:`config` module, it is overwritten. If you don't define :code:`REDIS_URL`, you can use the original value.
 When owattr read the dict, it casts dict value to type of the original value. So in environment variable, everything is str type. In this example, if you have defined :code:`IS_DEV_ENV=False` in environment variable, :code:`IS_DEV_ENV` of :code:`config` has :code:`False` as bool type.
+Booleans are cast as follows:
+
+- :code:`'false'`, :code:`'False'` and :code:`''` are cast to False
+- :code:`'true'` and :code:`'True'` are cast to True
+- anything else raises a :code:`'ValueError'`
 
 If your object has :code:`__all__`, owattr overwrites only variables which written in :code:`__all__`.

--- a/owattr.py
+++ b/owattr.py
@@ -1,6 +1,8 @@
 from typing import (
+    Any,
     Callable,
     Dict,
+    Type,
 )
 
 __all__ = ['from_dict']
@@ -29,5 +31,17 @@ def from_dict(target_object: object, new_attrs: Dict[str, str]) -> None:
         if isinstance(original_attr, Callable):  # type: ignore
             continue
 
-        Type = type(original_attr)
-        setattr(target_object, key, Type(new_attrs[key]))
+        new_attr = _cast_value(new_attrs[key], type(original_attr))
+        setattr(target_object, key, new_attr)
+
+
+def _cast_value(new_value: str, OriginalType: Type) -> Any:
+    # bool is a special case because bool('false') is True!
+    if OriginalType is bool:
+        if new_value in {'true', 'True'}:
+            return True
+        if new_value in {'', 'false', 'False'}:
+            return False
+        raise ValueError(new_value)
+
+    return OriginalType(new_value)

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,8 @@ import sys
 
 import owattr
 
+import pytest
+
 
 __all__ = ["NAME", "NUMBER", "test_class", "test_module"]
 
@@ -13,16 +15,37 @@ def test_class():
     class TargetObject:
         name = "A"
         number = 1
+        is_foo = True
+        is_bar = True
+        is_baz = False
 
     target_object = TargetObject()
 
     owattr.from_dict(target_object, {
         'name': "B",
         "number": "2",
+        "is_foo": "false",
+        "is_bar": "False",
+        "is_baz": "true",
     })
 
     assert target_object.name == "B"
     assert target_object.number == 2
+    assert target_object.is_foo is False
+    assert target_object.is_bar is False
+    assert target_object.is_baz is True
+
+
+def test_class_invalid_bool():
+    class TargetObject:
+        is_a_bool = True
+
+    target_object = TargetObject()
+
+    with pytest.raises(ValueError):
+        owattr.from_dict(target_object, {
+            'is_a_bool': 'no_it_is_not',
+        })
 
 
 def test_module():


### PR DESCRIPTION
Booleans are a special case because `bool('false') is True`, but they were handled in the same way as any other variable. So it was impossible to set a false environment variable except using `''`.
This improvement will enable to use:
- `'false'`, `'False'` and `''` for `False`
- `'true'` and `'True'` for `True`

Why those choices?
- True and False because it matches the repr in python
- true and false because pretty standard due to their use in JSON and JavaScript
- `''` in order to handle the empty case as false per default