### PR TITLE
Install the latest dependency libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - pip
 
 install:
-  - pip install -e .[test]
+  - pip install -U -e .[test]
 
 script:
   - flake8 .


### PR DESCRIPTION
TravisCI may not install the latest version of pytest. Because it's preinstalled now.
This change isn't the best. But I may migrate setup.py to Poetry in the future.